### PR TITLE
Fixed NullPointerException when used in Android

### DIFF
--- a/src/main/java/com/ubidots/ServerBridge.java
+++ b/src/main/java/com/ubidots/ServerBridge.java
@@ -80,7 +80,6 @@ public class ServerBridge {
 			}
 			
 			HttpResponse resp = client.execute(post);
-			resp.getEntity().getContent();
 			
 			BufferedReader rd = new BufferedReader(
                     new InputStreamReader(resp.getEntity().getContent()));


### PR DESCRIPTION
When working in Android, accessing the content returned by the HttpResponse twice, raised an Exception. Now this API works perfectly in Android, too.
